### PR TITLE
add missing packages to setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ Setup
 1. Install native dependencies
 
     - core tools
-        ```
+        ```bash
         sudo apt install git curl python-pip
-	sudo pip install --upgrade pip==9.0.3
+        sudo pip install --upgrade pip==9.0.3
         ```
 
     - ffmpeg (tested with 3.3.2)

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Setup
 
     - ffmpeg (tested with 3.3.2)
         ```bash
-        sudo apt install ffmpeg
+        sudo apt install ffmpeg libavformat-dev libavcodec-dev libavdevice-dev libavutil-dev libswscale-dev libavresample-dev libavfilter-dev
         ```
 
     - build tools

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Setup
 
     - core tools
         ```
-        sudo apt install git curl
+        sudo apt install git curl python-pip
         ```
 
     - ffmpeg (tested with 3.3.2)

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Setup
     - core tools
         ```
         sudo apt install git curl python-pip
+	sudo pip install --upgrade pip==9.0.3
         ```
 
     - ffmpeg (tested with 3.3.2)


### PR DESCRIPTION
Adds install of pip, pins pip version, and install libav*-dev packages.

Tested on a brand-new install of ubuntu-16.04.5-desktop-amd64.iso