### PR TITLE
normalize route names in the same way as is done later in the code

### DIFF
--- a/lib/route.py
+++ b/lib/route.py
@@ -11,7 +11,7 @@ CAMERA_FILENAMES = ['fcamera.hevc', 'acamera', 'icamera']
 
 class Route(object):
   def __init__(self, route_name, data_dir):
-    self.route_name = route_name
+    self.route_name = route_name.replace('_', '|')
     self._segments = self._get_segments(data_dir)
 
   @property


### PR DESCRIPTION
This lets you do
$ python replay/unlogger.py '03efb1fda29e30fe_2018-11-18--15-40-01' ~/Downloads

when you have a directory with
~/Downloads$ ls
03efb1fda29e30fe_2018-11-18--15-40-01--0--fcamera.hevc
03efb1fda29e30fe_2018-11-18--15-40-01--0--rlog.bz2

Otherwise the user has to know to replace the _ in filenames with | which is surprising.