### PR TITLE
Update boardd.py command line in for openpilot 0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Usage:
 python carcontrols/joystickd.py
 
 # In another terminal:
-selfdrive/boardd/boardd.py # Make sure the safety setting is hardcoded to ALL_OUTPUT
+selfdrive/boardd/tests/boardd_old.py # Make sure the safety setting is hardcoded to ALL_OUTPUT
 
 # In another terminal:
 python carcontrols/debug_controls.py


### PR DESCRIPTION
running boardd.py in the guide just recompiles cython module, replaced with correct path to old boardd.py script