### PR TITLE
lazy_property is not in common anymore.

### DIFF
--- a/replay/camera.py
+++ b/replay/camera.py
@@ -15,7 +15,7 @@ import traceback
 from collections import namedtuple
 from cereal import car
 from common.params import Params
-from common.lazy_property import lazy_property
+from tools.lib.lazy_property import lazy_property
 from selfdrive.messaging import sub_sock, recv_one_or_none, recv_one
 from selfdrive.services import service_list
 


### PR DESCRIPTION
lazy_property is not in common anymore. the lazy_property class moved to tools.lib.lazy_property. camera.py works again with that change